### PR TITLE
Add support for profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Please read the blog post here:
 
 Monitor all stack resource progress live (Interrupt with Ctrl-C):
 
-    aws-cloudformation-stack-status --watch --region $region --stack-name $stack
+    aws-cloudformation-stack-status --watch --region $region --stack-name $stack --profile $profile
 
-The `--stack-name` is optional, and multiple stacks can be monitored
+The `--stack-name` and `--profile` arguments are optional, and multiple stacks can be monitored
 together:
 
     watch aws-cloudformation-stack-status --watch $webstack $dbstack $dnsstack

--- a/aws-cloudformation-stack-status
+++ b/aws-cloudformation-stack-status
@@ -5,11 +5,13 @@
 # See: https://github.com/alestic/aws-cloudformation-stack-status
 #
 region_opt=
+profile_opt=
 stack_names=
 watch=
 while [ $# -gt 0 ]; do
   case $1 in
     --region)     region_opt="--region $2";               shift 2 ;;
+    --profile)    profile_opt="--profile $2";               shift 2 ;;
     --stack-name) stack_names="$stack_names $2";          shift 2 ;;
     --watch)      watch=1;                                shift ;;
     --*)          echo "$0: Unrecognized option: $1" >&2; exit 1  ;;
@@ -19,12 +21,13 @@ done
 set -- $stack_names $@
 
 if [ -n "$watch" ]; then
-  watch -t -n1 $0 $region_opt "$@"
+  watch -t -n1 $0 $region_opt $profile_opt "$@"
 fi
 
 for stack_name; do
   aws cloudformation describe-stack-events \
     $region_opt \
+    $profile_opt \
     --stack-name "$stack_name" \
     --output text \
     --query 'StackEvents[*].[ResourceStatus,LogicalResourceId,ResourceType,Timestamp]' |

--- a/aws-cloudformation-stack-status
+++ b/aws-cloudformation-stack-status
@@ -11,7 +11,7 @@ watch=
 while [ $# -gt 0 ]; do
   case $1 in
     --region)     region_opt="--region $2";               shift 2 ;;
-    --profile)    profile_opt="--profile $2";               shift 2 ;;
+    --profile)    profile_opt="--profile $2";             shift 2 ;;
     --stack-name) stack_names="$stack_names $2";          shift 2 ;;
     --watch)      watch=1;                                shift ;;
     --*)          echo "$0: Unrecognized option: $1" >&2; exit 1  ;;


### PR DESCRIPTION
The status script could only be used with default AWS CLI credentials
because the profile option was missing.

* Declares profile_opt variable
* Use profile_opt variable in describe-stack-events call