### PR TITLE
added support for multiple AWS accounts

### DIFF
--- a/aws-cloudformation-stack-status
+++ b/aws-cloudformation-stack-status
@@ -5,11 +5,13 @@
 # See: https://github.com/alestic/aws-cloudformation-stack-status
 #
 region_opt=
+profile_opt=
 stack_names=
 watch=
 while [ $# -gt 0 ]; do
   case $1 in
     --region)     region_opt="--region $2";               shift 2 ;;
+    --profile)    profile_opt="--profile $2";             shift 2 ;;
     --stack-name) stack_names="$stack_names $2";          shift 2 ;;
     --watch)      watch=1;                                shift ;;
     --*)          echo "$0: Unrecognized option: $1" >&2; exit 1  ;;
@@ -25,6 +27,7 @@ fi
 for stack_name; do
   aws cloudformation describe-stack-events \
     $region_opt \
+    $profile_opt \
     --stack-name "$stack_name" \
     --output text \
     --query 'StackEvents[*].[ResourceStatus,LogicalResourceId,ResourceType,Timestamp]' |


### PR DESCRIPTION
Thanks for the handy script. It broke while trying to use it with multiple accounts in my .aws/config with the `--profile` aws cli option. Added a few lines of copypasta to support multiple AWS account profiles.